### PR TITLE
Fix simple example

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,16 +8,20 @@ resource "aws_fsx_ontap_file_system" "this" {
   kms_key_id                        = var.kms_key_id
   automatic_backup_retention_days   = var.automatic_backup_retention_days
   daily_automatic_backup_start_time = var.daily_automatic_backup_start_time
-  disk_iops_configuration {
-    iops = var.iops
-    mode = var.mode
+  endpoint_ip_address_range         = var.endpoint_ip_address_range
+  storage_type                      = var.storage_type
+  fsx_admin_password                = var.fsx_admin_password
+  route_table_ids                   = var.route_table_ids
+  tags                              = var.tags
+  throughput_capacity               = var.throughput_capacity
+
+  dynamic "disk_iops_configuration" {
+    for_each = var.iops == null ? [] : [1]
+    content {
+      iops = var.iops
+      mode = var.mode
+    }
   }
-  endpoint_ip_address_range = var.endpoint_ip_address_range
-  storage_type              = var.storage_type
-  fsx_admin_password        = var.fsx_admin_password
-  route_table_ids           = var.route_table_ids
-  tags                      = var.tags
-  throughput_capacity       = var.throughput_capacity
 
   lifecycle {
     precondition {

--- a/variables.tf
+++ b/variables.tf
@@ -1,63 +1,39 @@
 variable "svm_vol_iterator" {
   type = map(object({
-    svm_name                               = string,
-    root_volume_security_style             = string,
-    tags                                   = map(string),
-    netbios_name                           = string,
-    dns_ips                                = list(string),
-    domain_name                            = string,
-    password                               = string,
-    username                               = string,
-    file_system_administrators_group       = string,
-    organizational_unit_distinguished_name = string,
-    enable_active_directory_configuration  = bool,
-    vol_map = map(object({
-      name                       = string,
-      junction_path              = string,
-      ontap_volume_type          = string,
-      security_style             = string,
-      size_in_megabytes          = number,
-      skip_final_backup          = bool,
-      storage_efficiency_enabled = bool,
-      tiering_policy_name        = string,
-      cooling_period             = number,
-      enable_tiering_policy      = bool
-    }))
+    svm_name                               = optional(string, "svm1"),
+    root_volume_security_style             = optional(string),
+    tags                                   = optional(map(string)),
+    netbios_name                           = optional(string),
+    dns_ips                                = optional(list(string)),
+    domain_name                            = optional(string),
+    password                               = optional(string),
+    username                               = optional(string),
+    file_system_administrators_group       = optional(string),
+    organizational_unit_distinguished_name = optional(string),
+    enable_active_directory_configuration  = optional(bool, false),
+    vol_map = optional(map(object({
+      name                       = optional(string, "vol1"),
+      size_in_megabytes          = optional(number, 100),
+      junction_path              = optional(string, "/vol1"),
+      ontap_volume_type          = optional(string),
+      security_style             = optional(string),
+      skip_final_backup          = optional(bool),
+      storage_efficiency_enabled = optional(bool, true),
+      tiering_policy_name        = optional(string),
+      cooling_period             = optional(number),
+      enable_tiering_policy      = optional(bool, false)
+    })), {})
   }))
   description = "(Optional) an object used to configure N number of SVMs with N number of volumes on each. Default behavior is 1 svm with 1 volume and no AD configuration"
   default = {
-    "svm1" = {
-      svm_name                               = "svm1"
-      root_volume_security_style             = null,
-      tags                                   = null,
-      netbios_name                           = null,
-      dns_ips                                = null,
-      domain_name                            = null,
-      password                               = null,
-      username                               = null,
-      file_system_administrators_group       = null,
-      organizational_unit_distinguished_name = null,
-      enable_active_directory_configuration  = null,
-      vol_map = {
-        "vol1" = {
-          name                       = "vol1"
-          size_in_megabytes          = 100
-          junction_path              = null,
-          ontap_volume_type          = null,
-          security_style             = null,
-          skip_final_backup          = null,
-          storage_efficiency_enabled = null,
-          tiering_policy_name        = null,
-          cooling_period             = null,
-          enable_tiering_policy      = false
-      } }
-  } }
+    "svm1" = {}
+  }
 }
 
 variable "storage_capacity" {
   type        = number
   description = "(Optional) The storage capacity (GiB) of the file system. Valid values between 1024 and 196608."
-  default     = null
+  default     = 1024
   validation {
     condition     = var.storage_capacity > 1024 || var.storage_capacity < 196608
     error_message = "Valid values are between 1024 and 196608 for FS storage capacity"
@@ -140,7 +116,7 @@ variable "mode" {
   description = "(Optional) - Specifies whether the number of IOPS for the file system is using the system. Valid values are AUTOMATIC and USER_PROVISIONED. Default value is AUTOMATIC."
   default     = null
   validation {
-    condition = var.mode == null ? true : var.mode == "AUTOMATIC" ? true : var.mode == "USER_PROVISIONED" ? true : false
+    condition     = var.mode == null ? true : var.mode == "AUTOMATIC" ? true : var.mode == "USER_PROVISIONED" ? true : false
     error_message = "Mode must be either AUTOMATIC or USER_PROVISIONED"
   }
 }


### PR DESCRIPTION
Fix:

```
terraform plan
╷
│ Error: Operation failed
│
│   on .terraform/modules/simple/variables.tf line 62, in variable "storage_capacity":
│   62:     condition     = var.storage_capacity > 1024 || var.storage_capacity < 196608
│     ├────────────────
│     │ var.storage_capacity is null
│
│ Error during operation: argument must not be null.
╵
╷
│ Error: Operation failed
│
│   on .terraform/modules/simple/variables.tf line 62, in variable "storage_capacity":
│   62:     condition     = var.storage_capacity > 1024 || var.storage_capacity < 196608
│     ├────────────────
│     │ var.storage_capacity is null
│
│ Error during operation: argument must not be null.
╵
```

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Missing required argument
│
│   with module.simple.module.svm_volume["svm1"].aws_fsx_ontap_storage_virtual_machine.this,
│   on .terraform/modules/simple/modules/svm_volume/main.tf line 1, in resource "aws_fsx_ontap_storage_virtual_machine" "this":
│    1: resource "aws_fsx_ontap_storage_virtual_machine" "this" {
│
│ The argument "active_directory_configuration.0.self_managed_active_directory_configuration.0.password" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│
│   with module.simple.module.svm_volume["svm1"].aws_fsx_ontap_storage_virtual_machine.this,
│   on .terraform/modules/simple/modules/svm_volume/main.tf line 1, in resource "aws_fsx_ontap_storage_virtual_machine" "this":
│    1: resource "aws_fsx_ontap_storage_virtual_machine" "this" {
│
│ The argument "active_directory_configuration.0.self_managed_active_directory_configuration.0.username" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│
│   with module.simple.module.svm_volume["svm1"].aws_fsx_ontap_storage_virtual_machine.this,
│   on .terraform/modules/simple/modules/svm_volume/main.tf line 1, in resource "aws_fsx_ontap_storage_virtual_machine" "this":
│    1: resource "aws_fsx_ontap_storage_virtual_machine" "this" {
│
│ The argument "active_directory_configuration.0.self_managed_active_directory_configuration.0.dns_ips" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│
│   with module.simple.module.svm_volume["svm1"].aws_fsx_ontap_storage_virtual_machine.this,
│   on .terraform/modules/simple/modules/svm_volume/main.tf line 1, in resource "aws_fsx_ontap_storage_virtual_machine" "this":
│    1: resource "aws_fsx_ontap_storage_virtual_machine" "this" {
│
│ The argument "active_directory_configuration.0.self_managed_active_directory_configuration.0.domain_name" is required, but no definition was found.
╵
```
Etc. 